### PR TITLE
Use block string as cheap string escape

### DIFF
--- a/yamlish.js
+++ b/yamlish.js
@@ -20,7 +20,7 @@ function encode (obj, indent) {
   switch (typeof obj) {
     case "string":
       obj = obj.trim()
-      if (obj.indexOf("\n") !== -1) {
+      if (/[:\n\[\]]/g.test(obj)) {
         return "|\n" + indent + obj.split(/\r?\n/).join("\n"+indent)
       } else {
         return (obj)


### PR DESCRIPTION
Strings like '[Date 01:23:45] foo' cannot be bare strings in YAML, but that is exactly the kind of thing you get if stderr consists of a single, timestamped line.

see: http://pyyaml.org/wiki/YAMLColonInFlowContext
